### PR TITLE
Allow editing actions and fix coordinate scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Las coordenadas capturadas se ajustan automáticamente para configuraciones con 
 
 Las acciones agregadas se muestran en la lista principal y se ejecutarán en orden.
 
+Si necesitas modificar algún paso, selecciona la acción en la lista y pulsa **Edit Action** para cambiar sus parámetros.
+
 ## Ejecutar
 
 Selecciona el número de *Cycles* y presiona **Play** para repetir la secuencia de acciones.


### PR DESCRIPTION
## Summary
- add *Edit Action* button to modify existing actions
- centralize coordinate capture logic and compute physical DPI scaling
- update docs with edit instructions

## Testing
- `python3 -m py_compile automation_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_685ee823bb948332946b82a08cd2632d