### PR TITLE
Use global coordinates for clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pulsa **Add Action** para elegir el tipo de acción:
 1. **Click**: todas las pantallas se oscurecen y el cursor se vuelve una cruz. Haz clic en la posición deseada para guardar las coordenadas. Durante la ejecución el programa moverá el mouse y hará clic en ese punto.
 2. **Sleep**: define un tiempo de espera (ahora admite decimales) antes de continuar con la siguiente acción.
 
-Las coordenadas capturadas se ajustan automáticamente para configuraciones con varias pantallas y escalado de alta densidad, para que cada clic ocurra en el punto exacto seleccionado.
+Las coordenadas capturadas se almacenan como posiciones globales en píxeles, por lo que cada clic ocurre exactamente en el punto seleccionado, incluso con varias pantallas o diferentes escalados.
 
 Las acciones agregadas se muestran en la lista principal y se ejecutarán en orden.
 
@@ -22,7 +22,6 @@ Selecciona el número de *Cycles* y presiona **Play** para repetir la secuencia 
 ## Modo de depuración
 
 Activa la casilla **Debug** para mostrar un marcador rojo en cada coordenada
-capturada y en cada clic ejecutado. En el registro se indicarán además las
-coordenadas lógicas y físicas obtenidas, así como la posición del mouse tras
-cada clic. Esto ayuda a diagnosticar problemas si el cursor no coincide con el
-punto seleccionado.
+capturada y en cada clic ejecutado. En el registro se indican las coordenadas
+globales obtenidas y la posición del mouse tras cada clic. Esto ayuda a
+diagnosticar problemas si el cursor no coincide con el punto seleccionado.

--- a/automation_gui.py
+++ b/automation_gui.py
@@ -136,19 +136,12 @@ class AutomationWindow(QtWidgets.QWidget):
         if 'x' not in coords:
             return None
 
-        screen = QtWidgets.QApplication.screenAt(QtCore.QPoint(coords['x'], coords['y']))
-        if screen:
-            ratio = screen.physicalDotsPerInch() / screen.logicalDotsPerInch()
-        else:
-            ratio = 1.0
-        phys_x = int(coords['x'] * ratio)
-        phys_y = int(coords['y'] * ratio)
         if self.debug_check.isChecked():
-            DebugOverlay(phys_x, phys_y)
+            DebugOverlay(coords['x'], coords['y'])
             self.append_log(
-                f"Picked logical ({coords['x']}, {coords['y']}) -> physical ({phys_x}, {phys_y})"
+                f"Picked global ({coords['x']}, {coords['y']})"
             )
-        return coords['x'], coords['y'], phys_x, phys_y
+        return coords['x'], coords['y']
 
     def add_action(self):
         action_types = ["Click", "Sleep"]
@@ -160,9 +153,9 @@ class AutomationWindow(QtWidgets.QWidget):
             result = self._pick_coordinates()
             if result is None:
                 return
-            logical_x, logical_y, phys_x, phys_y = result
-            action = {"type": "click", "x": phys_x, "y": phys_y}
-            label = f"Click ({logical_x}, {logical_y})"
+            x, y = result
+            action = {"type": "click", "x": x, "y": y}
+            label = f"Click ({x}, {y})"
         else:
             secs, ok = QtWidgets.QInputDialog.getDouble(
                 self, "Sleep", "Seconds:", 1.0, 0.1, 3600.0, decimals=2)
@@ -183,10 +176,10 @@ class AutomationWindow(QtWidgets.QWidget):
             result = self._pick_coordinates()
             if result is None:
                 return
-            logical_x, logical_y, phys_x, phys_y = result
-            action["x"] = phys_x
-            action["y"] = phys_y
-            label = f"Click ({logical_x}, {logical_y})"
+            x, y = result
+            action["x"] = x
+            action["y"] = y
+            label = f"Click ({x}, {y})"
         else:
             secs, ok = QtWidgets.QInputDialog.getDouble(
                 self, "Sleep", "Seconds:", action["seconds"], 0.1, 3600.0, decimals=2)


### PR DESCRIPTION
## Summary
- store global coordinates without applying DPI scaling
- log the picked pixel positions directly
- update README to describe global coordinate usage

## Testing
- `python -m py_compile automation_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_686014ad4c848332882ada7952b75e96