### PR TITLE
Add cycle manager and auto sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,24 @@ Este programa permite crear una lista de acciones sencillas para automatizar tar
 
 ## Agregar acciones
 
-Pulsa **Add Action** para elegir el tipo de acción:
+Utiliza los botones **Add Click** y **Add Sleep** para crear tu secuencia de acciones.
 
-1. **Click**: todas las pantallas se oscurecen y el cursor se vuelve una cruz. Haz clic en la posición deseada para guardar las coordenadas. Durante la ejecución el programa moverá el mouse y hará clic en ese punto.
-2. **Sleep**: define un tiempo de espera (ahora admite decimales) antes de continuar con la siguiente acción.
+1. **Add Click** abre el selector de coordenadas. Todas las pantallas se oscurecen y el cursor se vuelve una cruz. Haz clic en la posición deseada para guardar las coordenadas. Si tienes activado **Automatic Sleep**, justo después se agrega un Sleep con la duración configurada.
+2. **Add Sleep** te permite definir un tiempo de espera (admite decimales) antes de continuar con la siguiente acción.
 
 Las coordenadas capturadas se almacenan como posiciones globales en píxeles, por lo que cada clic ocurre exactamente en el punto seleccionado, incluso con varias pantallas o diferentes escalados.
 
 Las acciones agregadas se muestran en la lista principal y se ejecutarán en orden.
 
 Si necesitas modificar algún paso, selecciona la acción en la lista y pulsa **Edit Action** para cambiar sus parámetros.
+
+## Guardar ciclos de acciones
+
+Pulsa **Save Cycle** para guardar la lista actual de acciones con un nombre. Los ciclos guardados aparecen en la sección **Saved Cycles**, donde puedes renombrarlos, eliminarlos o insertarlos en la secuencia actual.
+
+## Componer secuencias
+
+Con los botones de **Insert**, puedes añadir un ciclo guardado al final de la lista de acciones. De esta forma es posible combinar varios ciclos y acciones sueltas antes de ejecutar la macro.
 
 ## Ejecutar
 


### PR DESCRIPTION
## Summary
- separate Add Click and Add Sleep buttons
- implement automatic sleep before each click
- allow saving action cycles to JSON and inserting them later
- add management UI for saved cycles
- update docs

## Testing
- `python -m py_compile automation_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_68601718735c8332b165908e67fc0173